### PR TITLE
[trans] FIX: This fixes the format output of trans.py to int

### DIFF
--- a/ecl2df/grid.py
+++ b/ecl2df/grid.py
@@ -444,6 +444,14 @@ def init2df(eclfiles: EclFiles, vectors: Union[str, List[str]] = None) -> pd.Dat
                 ]
             ),
         )
+
+        # np.hstack homogenizes the values' type to float, this brings
+        # the types back as it was defined when parsing it
+        for vec in usevectors:
+            init_df[vec] = init_df[vec].astype(
+                init.iget_named_kw(vec, 0).numpyView().dtype
+            )
+
         # libecl emits a number around -1.0000000200408773e+20 which
         # should be considered Not-a-number
         init_df = init_df.where(init_df > -1e20 + 1e13)  # some trial and error

--- a/tests/test_trans.py
+++ b/tests/test_trans.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     HAVE_NETWORKX = False
 
+import numpy as np
 import pandas as pd
 
 from ecl2df import ecl2csv, trans
@@ -91,6 +92,17 @@ def test_nx(tmp_path):
     assert network.number_of_nodes() == 6
     networkx.write_gexf(network, tmp_path / "reek-fipnum-trans.gxf", prettyprint=True)
     assert (tmp_path / "reek-fipnum-trans.gxf").is_file()
+
+
+def test_typenum():
+    """Test FIPNUM and EQLNUM types for integer"""
+    eclfiles = EclFiles(REEK)
+    trans_df = trans.df(eclfiles, vectors=["FIPNUM", "EQLNUM"])
+
+    assert isinstance(trans_df["FIPNUM1"][0], np.integer)
+    assert isinstance(trans_df["FIPNUM2"][0], np.integer)
+    assert isinstance(trans_df["EQLNUM1"][0], np.integer)
+    assert isinstance(trans_df["EQLNUM2"][0], np.integer)
 
 
 def test_main(tmp_path, mocker):


### PR DESCRIPTION
When using `np.hstack`, numpy homogenizes the formats to `float` which are carried on towards the output file when the user requests FIPNUM and/or EQLNUM.

This is somewhat the same problem of the coordinates in `grid_df`: https://github.com/equinor/ecl2df/blob/df10aa0aa191c0cb7cb96838f8fcb2c2f1792af8/ecl2df/grid.py#L342-L344

This fixes #361 adding both the code and proposed test.