### PR TITLE
Remove duplicate subparser

### DIFF
--- a/res2df/res2csv.py
+++ b/res2df/res2csv.py
@@ -24,7 +24,7 @@ For more documentation, see https://equinor.github.io/res2df/.
 CATEGORY: str = "utility.eclipse"
 EXAMPLES: str = """
 
-Outputting the EQUIL data from a .DATA file. This is implicitly 
+Outputting the EQUIL data from a .DATA file. This is implicitly
 supplied in ERT configs::
 
    FORWARD_MODEL RES2CSV(<SUBCOMMAND>=equil, <OUTPUT>=equil.csv)
@@ -174,16 +174,6 @@ def get_parser() -> argparse.ArgumentParser:
             "into one dataframe for all SATNUMs. Each row has data for a "
             "saturation point. For SWOF data, all columns related to SGOF "
             "are empty and vice versa"
-        ),
-    )
-    subparsers_dict["fipreports"] = subparsers.add_parser(
-        "fipreports",
-        help=("Extract FIPxxxxx REPORT REGION data from PRT output file."),
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description=(
-            "Extract FIPxxxxx REPORT REGION data from PRT file. "
-            "This parses currently in-place, outflows to wells and regions, and "
-            "material balance errors"
         ),
     )
     subparsers_dict["compdat"] = subparsers.add_parser(


### PR DESCRIPTION
In Python 3.11 adding the same subparser twice will raise an exception.

```sh
Traceback (most recent call last):
  File "/../res2df/bin/res2csv", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/../res2df/res2df/res2csv.py", line 311, in main
    parser = get_parser()
             ^^^^^^^^^^^^
  File "/../res2df/res2df/res2csv.py", line 179, in get_parser
    subparsers_dict["fipreports"] = subparsers.add_parser(
                                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/../lib/python3.11/argparse.py", line 1192, in add_parser
    raise ArgumentError(self, _('conflicting subparser: %s') % name)
argparse.ArgumentError: argument subcommand: conflicting subparser: fipreports
```