### PR TITLE
Expect RuntimeError or ValueError in ntequl test

### DIFF
--- a/tests/test_equil.py
+++ b/tests/test_equil.py
@@ -475,8 +475,10 @@ EQUIL
     df = equil.df(deckstr, ntequl=1)
     # We are not able to catch this situation..
     assert len(df) == 1
-    # But this will fail:
-    with pytest.raises(ValueError):
+    # But this will fail. Which exception is raised depends
+    # on the pybind11 version opm is built with which opm
+    # version is being used. Both are possible.
+    with pytest.raises((ValueError, RuntimeError)):
         equil.df(deckstr, ntequl=3)
 
     deckstr = """


### PR DESCRIPTION
Relates to Python 3.11+ support

Later versions of opm use a newer pybind11 version and potentially different exceptions for input errors in its C++ backend. This makes both `RuntimeError` and `ValueError` possible but tricky to pin down to a particular opm version. This takes the easy route and allows for both.