### PR TITLE
Draft: Partial deck parsing

### DIFF
--- a/res2df/compdat.py
+++ b/res2df/compdat.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 try:
     # pylint: disable=unused-import
-    import opm.io.deck
+    import opm.io
 except ImportError:
     # Allow parts of res2df to work without OPM:
     pass
@@ -993,7 +993,7 @@ def df(
     Returns:
         pd.Dataframe with one row pr cell to well connection
     """
-    compdat_df = deck2dfs(resdatafiles.get_deck())["COMPDAT"]
+    compdat_df = deck2dfs(resdatafiles.get_deck(sections=[opm.io.eclSectionType.SCHEDULE]))["COMPDAT"]
     compdat_df = unrolldf(compdat_df)
 
     if initvectors:

--- a/res2df/equil.py
+++ b/res2df/equil.py
@@ -112,7 +112,10 @@ def df(
         pd.DataFrame, at least with columns KEYWORD and EQLNUM
     """
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        try:
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.SOLUTION])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.SOLUTION])
 
     deck = inject_xxxdims_ntxxx("EQLDIMS", "NTEQUL", deck, ntequl)
     ntequl = deck["EQLDIMS"][0][DIMS_POS["NTEQUL"]].get_int(0)
@@ -328,7 +331,10 @@ def equil_main(args) -> None:
     )
     resdatafiles = ResdataFiles(args.DATAFILE)
     if resdatafiles:
-        deck = resdatafiles.get_deck()
+        try:
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.SOLUTION])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.SOLUTION])
     if "EQLDIMS" in deck:
         # Things are easier when a full deck with (correct) EQLDIMS
         # is supplied:

--- a/res2df/faults.py
+++ b/res2df/faults.py
@@ -40,7 +40,7 @@ def df(deck: Union[ResdataFiles, "opm.libopmcommon_python.Deck"]) -> pd.DataFram
         deck: A :term:`deck`
     """
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.GRID])
 
     # In[91]: list(deck['FAULTS'][0])
     # Out[91]: [[u'F1'], [36], [36], [41], [42], [1], [14], [u'I']]
@@ -91,7 +91,7 @@ def faults_main(args) -> None:
     )
     resdatafiles = ResdataFiles(args.DATAFILE)
     if resdatafiles:
-        deck = resdatafiles.get_deck()
+        deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.GRID])
     faults_df = df(deck)
     write_dframe_stdout_file(
         faults_df,

--- a/res2df/gruptree.py
+++ b/res2df/gruptree.py
@@ -70,7 +70,7 @@ def df(
         date = None
 
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
 
     edgerecords = []  # list of dict of rows containing an edge.
     nodedatarecords = []
@@ -457,7 +457,7 @@ def gruptree_main(args) -> None:
         print("Nothing to do. Set --output or --prettyprint")
         sys.exit(0)
     resdatafiles = ResdataFiles(args.DATAFILE)
-    dframe = df(resdatafiles.get_deck(), startdate=args.startdate)
+    dframe = df(resdatafiles.get_deck(sections=[opm.io.eclSectionType.SCHEDULE]), startdate=args.startdate)
     if args.prettyprint:
         if "DATE" in dframe:
             print(prettyprint(dframe))

--- a/res2df/pvt.py
+++ b/res2df/pvt.py
@@ -229,7 +229,10 @@ def df(
         pd.DataFrame
     """
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        try:
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.PROPS])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.PROPS])
 
     deck = inject_xxxdims_ntxxx("TABDIMS", "NTPVT", deck, ntpvt)
     ntpvt = deck["TABDIMS"][0][DIMS_POS["NTPVT"]].get_int(0)
@@ -299,7 +302,10 @@ def pvt_main(args) -> None:
     resdatafiles = ResdataFiles(args.DATAFILE)
     logger.info("Parsed %s", args.DATAFILE)
     if resdatafiles:
-        deck = resdatafiles.get_deck()
+        try:
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.PROPS])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.PROPS])
     if "TABDIMS" in deck:
         # Things are easier when a full deck with correct TABDIMS
         # is supplied:

--- a/res2df/resdatafiles.py
+++ b/res2df/resdatafiles.py
@@ -83,7 +83,7 @@ class ResdataFiles(object):
         """Return the full path to the directory with the .DATA file"""
         return Path(self._eclbase).absolute().parent
 
-    def get_deck(self) -> "opm.libopmcommon_python.Deck":
+    def get_deck(self, sections: list=[]) -> "opm.libopmcommon_python.Deck":
         """Return a opm.io :term:`deck` of the .DATA file"""
         if not self._deck:
             if Path(self._eclbase + ".DATA").is_file():
@@ -92,9 +92,18 @@ class ResdataFiles(object):
                 deckfile = self._eclbase  # Will be any filename
             logger.info("Parsing deck file %s...", deckfile)
             parsecontext = opm.io.ParseContext(OPMIOPARSER_RECOVERY)
-            deck = opm.io.Parser().parse(deckfile, parsecontext)
-            self._deck = deck
+            if len(sections) > 0:
+                try:
+                    deck = opm.io.Parser().parse(deckfile, parsecontext, sections)
+                    # Return without caching as only a part of the deck is parsed
+                    return deck
+                except RuntimeError:
+                    # Occurs if not able to parse individual sections
+                    # pass to parse and cache full deck
+                    pass
+            self._deck = opm.io.Parser().parse(deckfile, parsecontext)
         return self._deck
+
 
     @staticmethod
     def str2deck(

--- a/res2df/satfunc.py
+++ b/res2df/satfunc.py
@@ -216,7 +216,7 @@ def satfunc_main(args) -> None:
     if "TABDIMS" in deck:
         # Things are easier when a full deck with (correct) TABDIMS
         # is supplied:
-        satfunc_df = df(resdatafiles, keywords=args.keywords)
+        satfunc_df = df(deck, keywords=args.keywords)
     else:
         # This might be an include file for which we have to infer/guess
         # TABDIMS. Then we send it to df() as a string

--- a/res2df/satfunc.py
+++ b/res2df/satfunc.py
@@ -103,7 +103,10 @@ def df(
     if isinstance(deck, ResdataFiles):
         # NB: If this is done on include files and not on .DATA files
         # we can loose data for SATNUM > 1
-        deck = deck.get_deck()
+        try:
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.PROPS])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = deck.get_deck(sections=[opm.io.eclSectionType.PROPS])
     deck = inject_xxxdims_ntxxx("TABDIMS", "NTSFUN", deck, ntsfun)
     assert "TABDIMS" in deck
 
@@ -206,7 +209,10 @@ def satfunc_main(args) -> None:
     )
     resdatafiles = ResdataFiles(args.DATAFILE)
     if resdatafiles:
-        deck = resdatafiles.get_deck()
+        try:
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.RUNSPEC, opm.io.eclSectionType.PROPS])
+        except AttributeError: # opm<=2023.10 RUNSPEC is included by default and not an option.
+            deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.PROPS])
     if "TABDIMS" in deck:
         # Things are easier when a full deck with (correct) TABDIMS
         # is supplied:

--- a/res2df/vfp/_vfp.py
+++ b/res2df/vfp/_vfp.py
@@ -55,7 +55,7 @@ def basic_data(
     """
 
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
     elif isinstance(deck, str):
         deck = ResdataFiles.str2deck(deck)
 
@@ -259,7 +259,7 @@ def dfs(
                         Syntax "[0,1,8:11]" corresponds to [0,1,8,9,10,11].
     """
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
     elif isinstance(deck, str):
         deck = ResdataFiles.str2deck(deck)
 
@@ -302,7 +302,7 @@ def pyarrow_tables(
                         Syntax "[0,1,8:11]" corresponds to [0,1,8,9,10,11].
     """
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
     elif isinstance(deck, str):
         deck = ResdataFiles.str2deck(deck)
 
@@ -433,7 +433,7 @@ def df(
         return pd.DataFrame()
 
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
     elif isinstance(deck, str):
         deck = ResdataFiles.str2deck(deck)
 
@@ -507,7 +507,7 @@ def vfp_main(args) -> None:
         outputfile = args.output
         outputfile.replace(".arrow", "")
         vfp_arrow_tables = pyarrow_tables(
-            resdatafiles.get_deck(), keyword=args.keyword, vfpnumbers_str=vfpnumbers
+            resdatafiles, keyword=args.keyword, vfpnumbers_str=vfpnumbers
         )
         for vfp_table in vfp_arrow_tables:
             table_number = int(
@@ -520,7 +520,7 @@ def vfp_main(args) -> None:
             logger.info(f"Parsed file {args.DATAFILE} for vfp.dfs_arrow")
     else:
         dframe = df(
-            resdatafiles.get_deck(), keyword=args.keyword, vfpnumbers_str=vfpnumbers
+            resdatafiles, keyword=args.keyword, vfpnumbers_str=vfpnumbers
         )
         if args.output:
             write_dframe_stdout_file(

--- a/res2df/wcon.py
+++ b/res2df/wcon.py
@@ -36,7 +36,7 @@ def df(deck: Union[ResdataFiles, "opm.libopmcommon_python.Deck"]) -> pd.DataFram
     """
 
     if isinstance(deck, ResdataFiles):
-        deck = deck.get_deck()
+        deck = deck.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
 
     wconrecords = []  # List of dicts of every line in input file
     date = None  # DATE columns will always be there, but can contain NaN
@@ -98,7 +98,7 @@ def wcon_main(args) -> None:
     )
     resdatafiles = ResdataFiles(args.DATAFILE)
     if resdatafiles:
-        deck = resdatafiles.get_deck()
+        deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
     wcon_df = df(deck)
     write_dframe_stdout_file(
         wcon_df,

--- a/tests/test_resdatafiles.py
+++ b/tests/test_resdatafiles.py
@@ -75,6 +75,15 @@ def test_filedescriptors():
     assert len(list(fd_dir.glob("*"))) == pre_fd_count
     assert resdatafiles._rftfile is None
 
+    deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.PROPS])
+    assert ("WELSPECS" in deck) == False # verify section parsing
+    deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.SCHEDULE])
+    assert "WELSPECS" in deck # verify that last result was not cached
+    deck = resdatafiles.get_deck() # full deck will be cached
+    assert "SWOF" in deck
+    assert "WELSPECS" in deck
+    deck = resdatafiles.get_deck(sections=[opm.io.eclSectionType.PROPS])
+    assert "WELSPECS" in deck # verify that the full deck was cached and used
     resdatafiles.get_deck()
     # This should not leave any file descriptor open
     assert len(list(fd_dir.glob("*"))) == pre_fd_count


### PR DESCRIPTION
Quick attempt to resolve #260 

A small question is how to handle the caching of decks in `ResdataFiles`. In this draft I cached only if requesting the full deck, and returned the cached even if only sections are requested. That means that the returned value if requesting sections might vary dependent on whether or not a full deck has previously been requested. Considering this is mainly implemented for speed increase I think it could be ok, but open to discuss that.