### PR TITLE
Use resfo for parsing headers in UNRST file

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,9 @@
 [mypy-resdata.*]
 ignore_missing_imports = True
 
+[mypy-resfo.*]
+ignore_missing_imports = True
+
 [mypy-opm.*]
 ignore_missing_imports = True
 

--- a/res2df/grid.py
+++ b/res2df/grid.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 import pyarrow
 import pyarrow.feather
+import resfo
 from resdata.resfile import ResdataFile
 
 from .__version__ import __version__
@@ -199,11 +200,12 @@ def rst2df(
     # for all active cells:
     activecells = resdatafiles.get_egrid().getNumActive()
     rstvectors = []
-    for vec in resdatafiles.get_rstfile().headers:
-        if vec[1] == activecells and any(
-            fnmatch.fnmatch(vec[0], key) for key in vectors
+    for vec in resfo.lazy_read(resdatafiles.get_rstfilename()):
+        keyword_name = vec.read_keyword().strip()
+        if vec.read_length() == activecells and any(
+            fnmatch.fnmatch(keyword_name, key) for key in vectors
         ):
-            rstvectors.append(vec[0])
+            rstvectors.append(keyword_name)
     rstvectors = list(set(rstvectors))  # Make unique list
     # Note that all of these might not exist at all timesteps.
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ LONG_DESCRIPTION = (Path(__file__).parent / "README.md").read_text()
 SETUP_REQUIREMENTS = ["setuptools>=28", "setuptools_scm"]
 REQUIREMENTS = [
     "resdata>=5.0.0-b0",
+    "resfo",
     "numpy",
     "opm>=2020.10.2",
     "pandas",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ REQUIREMENTS = [
     "pyarrow",
     "pyyaml>=5.1",
     "treelib",
+    "xtgeo<4.3.2; python_version<='3.8'",
 ]
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
Using resdata to ask for headers implies reading the entire file which requires excessive memory.

Porting more of res2df to use resfo is postponed to a future issue.

Before this commit, obtaining the RST information for one particular date in a 118GB UNRST file was not possible (requires at least more than 118GB of available memory). With this commit, the same operation can be done in arund 6 GB of used memory.