### PR TITLE
Avoid crash-causing xtgeo version in Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
     "pyarrow",
     "pyyaml>=5.1",
     "treelib",
-    "xtgeo<4.3.2; python_version<='3.8'",
+    "xtgeo!=4.3.2; python_version<='3.8'",
 ]
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
xtgeo 4.3.2 caused crashes with pandas>2. Versions greater than this have resolved the problem, so far.