### PR TITLE
Add missing f-specifier for f-string

### DIFF
--- a/res2df/pvt.py
+++ b/res2df/pvt.py
@@ -375,7 +375,7 @@ def df2res_rock(dframe: pd.DataFrame, comment: Optional[str] = None) -> str:
         return "-- No data!"
     string = "ROCK\n"
     string += comment_formatter(comment)
-    string += "--   {'PRESSURE':^21} {'COMPRESSIBILITY':^21}\n"
+    string += f"--   {'PRESSURE':^21} {'COMPRESSIBILITY':^21}\n"
     # Use everything if KEYWORD not in dframe..
     subset = dframe if "KEYWORD" not in dframe else dframe[dframe["KEYWORD"] == "ROCK"]
     if "PVTNUM" not in subset:


### PR DESCRIPTION
The missing f caused an error in the printed comments, as in

```
-- Output file printed by res2df.pvt 1.3.0
--  at 2025-02-10 08:19:05.513992

PVDO
--         PRESSURE            VOLUMEFACTOR            VISCOSITY      
-- PVTNUM: 1
            10.0000000            1.0000000            1.0000000
           150.0000000            0.9000000            1.0000000
/

DENSITY
--        OILDENSITY           WATERDENSITY           GASDENSITY      
           800.0000000         1000.0000000            1.2000000 /

ROCK
--   {'PRESSURE':^21} {'COMPRESSIBILITY':^21}
           100.0000000            0.0001000 /

PVTW
--         PRESSURE            VOLUMEFACTOR         COMPRESSIBILITY          VISCOSITY           VISCOSIBILITY    
             1.0000000            1.0000000            0.0001000            0.2000000            0.0000100/

```