### PR TITLE
Make sourcing of eclrun non-flaky

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -3,6 +3,11 @@ install_test_dependencies () {
 }
 
 start_tests () {
+  SHELLOPTS_BEFORE=$(set +o)
+  set +e
+  # (this script becomes flaky if set -e is active)
   source /prog/res/ecl/script/eclrun.bash
+  eval "$SHELLOPTS_BEFORE"
+
   pytest --run-eclipse-simulator
 }


### PR DESCRIPTION
If there is a simple bash test that fails in the sourced file, the sourcing will fail when it is run in an environment where 'set -e' is set. Ensure this is temporarily unset