### PR TITLE
`fipreports`, fix crash in gas-water

### DIFF
--- a/res2df/fipreports.py
+++ b/res2df/fipreports.py
@@ -66,10 +66,10 @@ def report_block_lineparser(line: str) -> tuple:
         (liquid_oil, vapour_oil, total_oil) = map(
             float_or_nan, colonsections[2].split()
         )
+    elif len(colonsections[2].split()) == 2:
+        (liquid_oil, total_oil) = map(float_or_nan, colonsections[2].split())
     elif len(colonsections[2].split()) == 1:
         total_oil = float_or_nan(colonsections[2])
-    else:
-        (liquid_oil, total_oil) = map(float_or_nan, colonsections[2].split())
 
     total_water = float_or_nan(colonsections[3])
 

--- a/tests/test_fipreports.py
+++ b/tests/test_fipreports.py
@@ -226,6 +226,100 @@ def test_prtstring(tmp_path):
     pd.testing.assert_frame_equal(dframe, expected_dframe)
 
 
+def test_gaswater_report(tmp_path):
+    """Two-phase gas water run"""
+    prtstring = """
+                                              =================================
+                                                : FIPNUM  REPORT REGION    2    :
+                                                :     PAV =       4045.00  BARSA:
+                                                :     PORV=     27000000.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :                                           :      19135648. :      8457278.                     8457278.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :                                           :             0. :            0.                           0.:
+ :OUTFLOW THROUGH WELLS    :                                           :             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                           :             0. :                                         0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :                                           :      19135648. :      8457278.                     8457278.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+"""  # noqa
+    os.chdir(tmp_path)
+    Path("FOO.PRT").write_text(prtstring, encoding="utf8")
+    dframe = fipreports.df("FOO.PRT").set_index("DATATYPE")
+    print(dframe.to_string())
+    assert dframe["REGION"].unique() == [2]
+    pd.testing.assert_frame_equal(
+        dframe.reset_index().drop(["DATE", "REGION"], axis="columns"),
+        pd.DataFrame(
+            [
+                {
+                    "DATATYPE": "CURRENTLY IN PLACE",
+                    "FIPNAME": "FIPNUM",
+                    "TO_REGION": None,
+                    "STOIIP_OIL": None,
+                    "ASSOCIATEDOIL_GAS": None,
+                    "STOIIP_TOTAL": None,
+                    "WIIP_TOTAL": 19135648.0,
+                    "GIIP_GAS": 8457278.0,
+                    "ASSOCIATEDGAS_OIL": None,
+                    "GIIP_TOTAL": 8457278.0,
+                },
+                {
+                    "DATATYPE": "OUTFLOW TO OTHER REGIONS",
+                    "FIPNAME": "FIPNUM",
+                    "TO_REGION": None,
+                    "STOIIP_OIL": None,
+                    "ASSOCIATEDOIL_GAS": None,
+                    "STOIIP_TOTAL": None,
+                    "WIIP_TOTAL": 0.0,
+                    "GIIP_GAS": 0.0,
+                    "ASSOCIATEDGAS_OIL": None,
+                    "GIIP_TOTAL": 0.0,
+                },
+                {
+                    "DATATYPE": "OUTFLOW THROUGH WELLS",
+                    "FIPNAME": "FIPNUM",
+                    "TO_REGION": None,
+                    "STOIIP_OIL": None,
+                    "ASSOCIATEDOIL_GAS": None,
+                    "STOIIP_TOTAL": None,
+                    "WIIP_TOTAL": 0.0,
+                    "GIIP_GAS": np.nan,
+                    "ASSOCIATEDGAS_OIL": None,
+                    "GIIP_TOTAL": 0.0,
+                },
+                {
+                    "DATATYPE": "MATERIAL BALANCE ERROR.",
+                    "FIPNAME": "FIPNUM",
+                    "TO_REGION": None,
+                    "STOIIP_OIL": None,
+                    "ASSOCIATEDOIL_GAS": None,
+                    "STOIIP_TOTAL": None,
+                    "WIIP_TOTAL": 0.0,
+                    "GIIP_GAS": np.nan,
+                    "ASSOCIATEDGAS_OIL": None,
+                    "GIIP_TOTAL": 0.0,
+                },
+                {
+                    "DATATYPE": "ORIGINALLY IN PLACE",
+                    "FIPNAME": "FIPNUM",
+                    "TO_REGION": None,
+                    "STOIIP_OIL": None,
+                    "ASSOCIATEDOIL_GAS": None,
+                    "STOIIP_TOTAL": None,
+                    "WIIP_TOTAL": 19135648.0,
+                    "GIIP_GAS": 8457278.0,
+                    "ASSOCIATEDGAS_OIL": None,
+                    "GIIP_TOTAL": 8457278.0,
+                },
+            ]
+        ),
+    )
+
+
 def test_drygas_report(tmp_path):
     """Excerpt from a two-phase gas water run"""
     prtstring = """


### PR DESCRIPTION
Close #453 

When running gas-water case, we see that the oil sections are typically empty, this caused crash since `fipreports` is expecting 1 - 3 columns. This PR will make it handle the case with 0 columns

