### PR TITLE
Remove sphinx configuration no longer valid

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,6 @@ markers =
     integration: marks a test as an integration test
     requires_eclipse: A test that requires the Eclipse simulator
 
-[build_sphinx]
-all-files = 1
-warning-is-error = 1
-
 [rstcheck]
 ignore_directives=argparse,automodule
 # This looks like a bug in rstcheck:


### PR DESCRIPTION
Resolves CI build failure in https://github.com/equinor/res2df/actions/runs/14398733428/job/40379506011

Removing these settings does not affect the built documentation as far as I can see.

Building sphinx on a setup.py project is deprecated.