### PR TITLE
feat(ci): add PyPI publish workflow and update badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/res2df
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install build dependencies
+        run: |
+          pip install -U pip
+          pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/res2df.yml
+++ b/.github/workflows/res2df.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  release:
-    types:
-      - published
 
   schedule:
     # Run CI every night and check that tests are working with latest dependencies
@@ -100,13 +97,3 @@ jobs:
               git commit -m "Update Github Pages"
               git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
             fi
-
-      - name: Build python package and publish to pypi
-        if: github.event_name == 'release' && matrix.python-version == '3.11'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.res2df_pypi_token }}
-        run: |
-          python -m pip install --upgrade build twine
-          python -m build
-          twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://github.com/equinor/res2df/actions/workflows/res2df.yml/badge.svg)](https://github.com/equinor/res2df/actions/workflows/res2df.yml)
+[![Publish to PyPI](https://github.com/equinor/res2df/actions/workflows/publish.yml/badge.svg)](https://github.com/equinor/res2df/actions/workflows/publish.yml)
+[![PyPI version](https://img.shields.io/pypi/v/res2df.svg)](https://pypi.org/project/res2df/)
 [![codecov](https://codecov.io/gh/equinor/res2df/graph/badge.svg?token=3sZBGGu5VG)](https://codecov.io/gh/equinor/res2df)
 [![Python 3.11-3.12](https://img.shields.io/badge/python-3.11%20|%203.12-blue.svg)](https://www.python.org)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for publishing to PyPI
- Removed PyPI publishing logic from the existing CI workflow
- Updated README with badges for PyPI publish status and version